### PR TITLE
Fix for turning on/off RGBW devices

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -199,12 +199,12 @@ class BasePlugin:
               Domoticz.Debug(str(e))
          else:
            if device_id[3]=="rgb":
-             mqttpath = self.base_topic+"/"+device_id[0]+"-"+device_id[1]+"/color/"+device_id[2]+"/set"
+             mqttpath = self.base_topic+"/"+device_id[0]+"-"+device_id[1]+"/color/"+device_id[2]+"/command"
            else:
-             mqttpath = self.base_topic+"/"+device_id[0]+"-"+device_id[1]+"/white/"+device_id[2]+"/set"
+             mqttpath = self.base_topic+"/"+device_id[0]+"-"+device_id[1]+"/white/"+device_id[2]+"/command"
            cmd = Command.strip().lower()
            if cmd in ["on","off"]:        # commands are simply on or off
-            scmd = '{"turn":"'+str(cmd)+'"}'
+            scmd = str(cmd)
             try:
              self.mqttClient.publish(mqttpath, scmd)
              if cmd=="off":


### PR DESCRIPTION
I had an problem with turning on my Shelly Bulb.
According to https://shelly-api-docs.shelly.cloud/#bulb-mqtt
and https://shelly-api-docs.shelly.cloud/#rgbw2-mqtt
both have the same command for turning on and off, so i think there was an bug in the code.
Don't have RGBW2 to test, but with Bulb it works fine.