### PR TITLE
Add support for energy meter power factor value

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -352,6 +352,8 @@ class BasePlugin:
             unitname=mqttpath[1]+"-"+str(funcid)+"-rtotal" # EM
           elif subval=="current":
            unitname=mqttpath[1]+"-"+str(funcid)+"-current" # Shelly EM current meter
+          elif subval=="pf":
+           unitname=mqttpath[1]+"-"+str(funcid)+"-pf" # Shelly EM pf
           iUnit = -1
           for Device in Devices:
            try:
@@ -375,6 +377,8 @@ class BasePlugin:
               Domoticz.Device(Name=unitname, Unit=iUnit,Type=243,Subtype=8,Used=1,DeviceID=unitname).Create()
              elif subval=="current":
               Domoticz.Device(Name=unitname, Unit=iUnit,Type=243,Subtype=23,Used=1,DeviceID=unitname).Create()
+             elif subval=="pf":
+              Domoticz.Device(Name=unitname, Unit=iUnit,Type=243,Subtype=31,Used=0,DeviceID=unitname).Create()
              elif self.powerread:
               if "energy" in subval or "power" in subval or "total" in subval:
                Domoticz.Device(Name=unitname, Unit=iUnit,Type=243,Subtype=29,Used=0,DeviceID=unitname).Create()
@@ -392,7 +396,7 @@ class BasePlugin:
            except Exception as e:
             Domoticz.Debug(str(e))
             return False
-          elif subval in ["voltage","current"]:
+          elif subval in ["voltage","current","pf"]:
            try:
             mval = float(str(message).strip())
            except:


### PR DESCRIPTION
Based on MQTT messages:
```
shellies/shellyem3-68C63AFAF952/relay/0 off
shellies/shellyem3-68C63AFAF952/emeter/0/power 120.11
shellies/shellyem3-68C63AFAF952/emeter/0/pf 0.71
shellies/shellyem3-68C63AFAF952/emeter/0/current 0.71
shellies/shellyem3-68C63AFAF952/emeter/0/voltage 239.03
shellies/shellyem3-68C63AFAF952/emeter/1/power 116.23
shellies/shellyem3-68C63AFAF952/emeter/1/pf 0.71
shellies/shellyem3-68C63AFAF952/emeter/1/current 0.69
shellies/shellyem3-68C63AFAF952/emeter/1/voltage 237.51
shellies/shellyem3-68C63AFAF952/emeter/2/power 76.46
shellies/shellyem3-68C63AFAF952/emeter/2/pf 0.54
shellies/shellyem3-68C63AFAF952/emeter/2/current 0.59
shellies/shellyem3-68C63AFAF952/emeter/2/voltage 240.50
```