### PR TITLE
Support Shelly Plus H&T

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ http://mosquitto.org/blog/2013/01/mosquitto-debian-repository/
 
 !!! Please, DO NOT CHECK "Use custom MQTT prefix" on your device settings page if you want to use this plugin as this will render device detection unusable !!!
 
+!!! For Shelly Plus HT, please prefix the MQTT topic with `shellies/` on your device settings page to make it send on the same topic as other devices !!!
+
 ## Installation
 
 1. Clone repository into your domoticz plugins folder
@@ -79,6 +81,7 @@ Tested and working with:
  - Shelly 1L (relay)
  - Shelly Gas
  - Shelly Motion
+ - Shelly Plus H&T (by setting MQTT prefix to `shellies`)
 
 **I can only support devices that i have. Thank you for your understanding.**
 


### PR DESCRIPTION
Shelly Plus H&T sends a single MQTT message containing all the data. 

Example:
```
{"src":"shellyplusht-c049ef8bc088","dst":"shellyplusht-c049ef8bc088/events","method":"NotifyFullStatus","params":{"ts":1669541352.21,"ble":{},"cloud":{"connected":false},"devicepower:0":{"id": 0,"battery":{"V":0.43, "percent":0},"external":{"present":true}},"ht_ui":{},"humidity:0":{"id": 0,"rh":57.6},"mqtt":{"connected":true},"sys":{"mac":"C049EF8BC088","restart_required":false,"time":null,"unixtime":null,"uptime":0,"ram_size":235712,"ram_free":166028,"fs_size":458752,"fs_free":167936,"cfg_rev":14,"kvs_rev":0,"webhook_rev":0,"available_updates":{},"wakeup_reason":{"boot":"deepsleep_wake","cause":"status_update"},"wakeup_period":600},"temperature:0":{"id": 0,"tC":19.0, "tF":66.2},"wifi":{"sta_ip":"192.168.1.43","status":"got ip","ssid":"MyWifi","rssi":-60},"ws":{"connected":false}}}
```

By default, the topic is directly the device name (here `shellyplusht-c049ef8bc088`) at the root level => we need to change Shelly Plus H&T configuration to add the `shellies/` prefix.

Tested on my own Domoticz setup successfully.